### PR TITLE
Cleanup conditional structures

### DIFF
--- a/manifests/directory.pp
+++ b/manifests/directory.pp
@@ -4,32 +4,28 @@ define puppet_audit::directory(
   $group,
   $mode,
   $owner,
-  $tags = '',
+  $tags = undef,
   $filepath = "${title}",
-  )
-  {
-    case $tags{
-    '': {
-
-      file { "${filepath}" :
-        ensure  => directory,
-        group   => "${group}",
-        mode    => "${mode}",
-        owner   => "${owner}",
-        noop    => true,
-        replace => true,
-      }
+)
+{
+  if $tags {
+    file { "${filepath}" :
+      ensure  => directory,
+      group   => "${group}",
+      mode    => "${mode}",
+      owner   => "${owner}",
+      noop    => true,
+      replace => true,
+      tag     => "${tags}",
     }
-    default:  {
-      file { "${filepath}" :
-        ensure  => directory,
-        group   => "${group}",
-        mode    => "${mode}",
-        owner   => "${owner}",
-        noop    => true,
-        replace => true,
-        tag     => "${tags}",
-      }
+  } else {
+    file { "${filepath}" :
+      ensure  => directory,
+      group   => "${group}",
+      mode    => "${mode}",
+      owner   => "${owner}",
+      noop    => true,
+      replace => true,
     }
   }
 }

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -5,34 +5,30 @@ define puppet_audit::file(
   $group,
   $mode,
   $owner,
-  $tags = '',
+  $tags = undef,
   $filepath = "${title}",
-  )
-  {
-    case $tags{
-    '': {
-
-      file { "${filepath}" :
-        ensure  => file,
-        content => "${fileMD5}",
-        group   => "${group}",
-        mode    => "${mode}",
-        owner   => "${owner}",
-        noop    => true,
-        replace => true,
-      }
+)
+{
+  if $tags {
+    file { "${filepath}" :
+      ensure  => file,
+      content => "${fileMD5}",
+      group   => "${group}",
+      mode    => "${mode}",
+      owner   => "${owner}",
+      noop    => true,
+      replace => true,
+      tag     => "${tags}",
     }
-    default:  {
-      file { "${filepath}" :
-        ensure  => file,
-        content => "${fileMD5}",
-        group   => "${group}",
-        mode    => "${mode}",
-        owner   => "${owner}",
-        noop    => true,
-        replace => true,
-        tag     => "${tags}",
-      }
+  } else {
+    file { "${filepath}" :
+      ensure  => file,
+      content => "${fileMD5}",
+      group   => "${group}",
+      mode    => "${mode}",
+      owner   => "${owner}",
+      noop    => true,
+      replace => true,
     }
   }
 }

--- a/manifests/link.pp
+++ b/manifests/link.pp
@@ -1,38 +1,35 @@
 # == Class puppet_audit::link
+i
 #
 define puppet_audit::link(
   $group,
   $mode,
   $owner,
   $target,
-  $tags = '',
-  $linkfilepath = "${title}",  
-  )
-  {
-    case $tags{
-    '': {
-
-      file { "${linkfilepath}" :
-        ensure  => link,
-        group   => "${group}",
-        mode    => "${mode}",
-        owner   => "${owner}",
-        target  => "${target}",
-        noop    => true,
-        replace => true,
-      }
+  $tags = undef,
+  $linkfilepath = "${title}",
+)
+{
+  if $tags {
+    file { "${linkfilepath}" :
+      ensure  => link,
+      group   => "${group}",
+      mode    => "${mode}",
+      owner   => "${owner}",
+      target  => "${target}",
+      noop    => true,
+      replace => true,
+      tag     => "${tags}",
     }
-    default:  {
-      file { "${linkfilepath}" :
-        ensure  => link,
-        group   => "${group}",
-        mode    => "${mode}",
-        owner   => "${owner}",
-        target  => "${target}",
-        noop    => true,
-        replace => true,
-        tag     => "${tags}",
-      }
+  } else  {
+    file { "${linkfilepath}" :
+      ensure  => link,
+      group   => "${group}",
+      mode    => "${mode}",
+      owner   => "${owner}",
+      target  => "${target}",
+      noop    => true,
+      replace => true,
     }
   }
 }


### PR DESCRIPTION
The conditional structures previously used were based on 'case'
statements in a situation where a simpler and more readable `if`
statement would suffice.

This commit clean up the code by switching to a default of `undef` for
the `tags` parameter in the three defined types. This allows a simple
`if` statement to run against the truthyness of the parameter. In
general this should be far more readable.